### PR TITLE
chore: update genkit and dependencies to version 1.0.5

### DIFF
--- a/genkit/package-lock.json
+++ b/genkit/package-lock.json
@@ -13,19 +13,19 @@
         "@genkit-ai/express": "^1.0.4",
         "@genkit-ai/googleai": "^1.0.4",
         "@genkit-ai/vertexai": "^1.0.4",
-        "express": "^4.21.2",
-        "genkit": "^1.0.4"
+        "express": "^4.21.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^22.10.1",
+        "genkit": "^1.0.5",
         "genkit-cli": "^1.0.4",
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": "23.6.0"
+        "node": "22.14.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -649,12 +649,12 @@
       }
     },
     "node_modules/@genkit-ai/ai": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.0.4.tgz",
-      "integrity": "sha512-omByB//cj5476YU+wdoVuhNI0En85kITjSxVwqVBz94hcP5hYhQfcfhNlN6BzhgNJER7XACyYKWehmw4KwxoLQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.0.5.tgz",
+      "integrity": "sha512-3OOi/q5K7Ab6UenazPHK1VBUiFRUG3y+7tF7pE678ik0uVwdVNXVfNoWqznSdfsnjrf+k28ZfBCiJzeWvISebQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@genkit-ai/core": "1.0.4",
+        "@genkit-ai/core": "1.0.5",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.11.19",
         "colorette": "^2.0.20",
@@ -663,6 +663,32 @@
         "node-fetch": "^3.3.2",
         "partial-json": "^0.1.7",
         "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/@genkit-ai/ai/node_modules/@genkit-ai/core": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.0.5.tgz",
+      "integrity": "sha512-K8U2nAfbizzgmy7Kvb+YeWTMdBWy6n23r9OzBAl8bVI+FaBqY6b6avVWku7/HsJHEhxyQ+PI/uCXXzdHuVcV3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.25.0",
+        "@opentelemetry/core": "^1.25.0",
+        "@opentelemetry/sdk-metrics": "^1.25.0",
+        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-trace-base": "^1.25.0",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "async-mutex": "^0.5.0",
+        "body-parser": "^1.20.3",
+        "cors": "^2.8.5",
+        "dotprompt": "^1.0.0",
+        "express": "^4.21.0",
+        "get-port": "^5.1.0",
+        "json-schema": "^0.4.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.22.4"
       }
     },
     "node_modules/@genkit-ai/ai/node_modules/@types/node": {
@@ -698,6 +724,7 @@
       "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.0.4.tgz",
       "integrity": "sha512-O4ASgeXLkjc8qyhgUhY9TV//V0W6tvhv7YV0LEdeQ6Vum7CvdBNB1w8moUQADeyMPE00VuqURcGKpejVshY3OQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.25.0",
@@ -3998,13 +4025,13 @@
       }
     },
     "node_modules/genkit": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.0.4.tgz",
-      "integrity": "sha512-QJBvz8tJBQaqaHwBge3Hf4xoDNWJ8VVyDtKJsbCGEMwKnZa+g9Qh3LyBPx14RpPpJizZrr2j8Rvv0IocMEaj6Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.0.5.tgz",
+      "integrity": "sha512-jCht3b64ITtmiJ+DCqYlRMBO0+r239repA6rOzHzia6K2mnnFiPiyEJKrSsKHh0c/IC0g9BramIQ6lq+sLuPqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@genkit-ai/ai": "1.0.4",
-        "@genkit-ai/core": "1.0.4",
+        "@genkit-ai/ai": "1.0.5",
+        "@genkit-ai/core": "1.0.5",
         "uuid": "^10.0.0"
       }
     },
@@ -4028,6 +4055,32 @@
       },
       "bin": {
         "genkit": "dist/bin/genkit.js"
+      }
+    },
+    "node_modules/genkit/node_modules/@genkit-ai/core": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.0.5.tgz",
+      "integrity": "sha512-K8U2nAfbizzgmy7Kvb+YeWTMdBWy6n23r9OzBAl8bVI+FaBqY6b6avVWku7/HsJHEhxyQ+PI/uCXXzdHuVcV3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.25.0",
+        "@opentelemetry/core": "^1.25.0",
+        "@opentelemetry/sdk-metrics": "^1.25.0",
+        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-trace-base": "^1.25.0",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "async-mutex": "^0.5.0",
+        "body-parser": "^1.20.3",
+        "cors": "^2.8.5",
+        "dotprompt": "^1.0.0",
+        "express": "^4.21.0",
+        "get-port": "^5.1.0",
+        "json-schema": "^0.4.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.22.4"
       }
     },
     "node_modules/genkit/node_modules/uuid": {

--- a/genkit/package.json
+++ b/genkit/package.json
@@ -18,6 +18,7 @@
     "@types/express": "^5.0.0",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.10.1",
+    "genkit": "^1.0.5",
     "genkit-cli": "^1.0.4",
     "typescript": "^5.7.2"
   },
@@ -26,7 +27,6 @@
     "@genkit-ai/express": "^1.0.4",
     "@genkit-ai/googleai": "^1.0.4",
     "@genkit-ai/vertexai": "^1.0.4",
-    "express": "^4.21.2",
-    "genkit": "^1.0.4"
+    "express": "^4.21.2"
   }
 }


### PR DESCRIPTION
- Updated genkit to version 1.0.5 in package-lock.json and package.json
- Updated @genkit-ai/ai and @genkit-ai/core to version 1.0.5 in package-lock.json
- Changed node engine requirement from 23.6.0 to 22.14.0 in package-lock.json