### PR TITLE
refactor: update app bar titles and simplify settings page

### DIFF
--- a/lib/pages/chat_room_page.dart
+++ b/lib/pages/chat_room_page.dart
@@ -87,7 +87,7 @@ class ChatRoomPageState extends State<ChatRoomPage> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-        appBar: CustomAppBar(title: 'チャット'),
+        appBar: CustomAppBar(),
         body: Chat(
           user: _user,
           messages: _messages,

--- a/lib/pages/lifestyle_page.dart
+++ b/lib/pages/lifestyle_page.dart
@@ -46,9 +46,7 @@ class _LifestylePageState extends State<LifestylePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const CustomAppBar(
-        title: 'ポリシー',
-      ),
+      appBar: const CustomAppBar(),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -97,7 +95,7 @@ class _LifestylePageState extends State<LifestylePage> {
         items: const [
           BottomNavigationBarItem(
             icon: Icon(Icons.person),
-            label: 'ポリシー',
+            label: 'プロフィール',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.chat),

--- a/lib/pages/setting_page.dart
+++ b/lib/pages/setting_page.dart
@@ -108,7 +108,7 @@ class _SettingPageState extends State<SettingPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomAppBar(title: '設定'),
+      appBar: CustomAppBar(),
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : SingleChildScrollView(
@@ -143,40 +143,19 @@ class _SettingPageState extends State<SettingPage> {
                   ),
 
                   const SizedBox(height: 30),
-
-                  // Danger zone
-                  const Text(
-                    '危険ゾーン',
-                    style: TextStyle(
-                      fontSize: 22,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.red,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  Card(
-                    color: Colors.red.shade50,
-                    child: Padding(
-                      padding: const EdgeInsets.all(12.0),
-                      child: Column(
-                        children: [
-                          ListTile(
-                            leading: const Icon(Icons.delete_forever,
-                                color: Colors.red),
-                            title: const Text('アカウントを削除',
-                                style: TextStyle(fontWeight: FontWeight.bold)),
-                            subtitle: const Text(
-                                'アカウントとすべてのデータを完全に削除します。この操作は取り消せません。'),
-                            trailing: ElevatedButton(
-                              onPressed: () => _deleteAccount(context),
-                              style: ElevatedButton.styleFrom(
-                                backgroundColor: Colors.red,
-                                foregroundColor: Colors.white,
-                              ),
-                              child: const Text('削除'),
-                            ),
-                          ),
-                        ],
+                  Center(
+                    child: ElevatedButton(
+                      onPressed: () => _deleteAccount(context),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red,
+                        foregroundColor: Colors.white,
+                      ),
+                      child: const Text(
+                        'アカウントを削除する',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
- Removed titles from CustomAppBar in ChatRoomPage and LifestylePage.
- Changed label from 'ポリシー' to 'プロフィール' in LifestylePage's BottomNavigationBar.
- Simplified the settings page by removing the danger zone section and added a delete account button.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- **Refactor**: `CustomAppBar`からタイトルを削除し、ユーザーインターフェースを簡素化しました。
- **Change**: `LifestylePage`の`BottomNavigationBar`ラベルを「ポリシー」から「プロフィール」に変更しました。
- **New Feature**: 設定ページにアカウント削除ボタンを追加し、中央に配置しました。
- **Chore**: 危険ゾーンセクションを削除し、設定ページをより使いやすくしました。

これらの変更により、ユーザー体験が向上します。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->