### PR TITLE
chore:project-idを設定した

### DIFF
--- a/.github/workflows/backend_deploy.yml
+++ b/.github/workflows/backend_deploy.yml
@@ -28,20 +28,6 @@ jobs:
         cache: 'npm'
         cache-dependency-path: './functions/package-lock.json'
     
-    - name: Debug token availability
-      run: |
-        echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN exists: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
-        echo "ACTIONS_ID_TOKEN_REQUEST_URL exists: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
-
-    - name: Debug GitHub context
-      run: |
-        echo "Repository: ${{ github.repository }}"
-        echo "Ref: ${{ github.ref }}"
-        echo "Actor: ${{ github.actor }}"
-        echo "Repository Owner: ${{ github.repository_owner }}"
-        echo "Head Ref: ${{ github.head_ref }}"
-        echo "Base Ref: ${{ github.base_ref }}"
-
     - name: Install dependencies
       working-directory: ./functions
       run: npm ci
@@ -64,4 +50,4 @@ jobs:
     - name: Deploy to Functions
       run: |
         npm install -g firebase-tools
-        firebase deploy --only functions --force --project=bar-project
+        firebase deploy --only functions --project=${{ secrets.FIREBASE_PROJECT_ID }} --non-interactive


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: デバッグ用トークンとGitHubコンテキストに関する出力ステップを削除
- Chore: FirebaseプロジェクトIDの指定方法をハードコーディングからシークレット環境変数`${{ secrets.FIREBASE_PROJECT_ID }}`に変更
- Chore: `firebase deploy`コマンドに`--non-interactive`オプションを追加

これにより、デプロイメントプロセスが安全かつ効率的になり、ユーザー体験が向上します。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->