### PR TITLE
fix: ensure controller emits null on user deletion in FakeAuthService

### DIFF
--- a/test/mocks/fake_auth_service.dart
+++ b/test/mocks/fake_auth_service.dart
@@ -52,6 +52,7 @@ class FakeAuthService implements AuthService {
       throw AppAuthException('no-user', 'No current user to delete');
     }
     _user = null;
+    _controller.add(null);
   }
 
   @override


### PR DESCRIPTION
This pull request makes a minor update to the `FakeAuthService` mock used in tests. After the user is deleted, the service now notifies listeners by emitting a `null` value on the user stream, ensuring that any subscribers are properly updated about the user's deletion.